### PR TITLE
Set up continuous integration using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,130 @@
+
+name: Continuous integration
+on:
+  - push
+  - pull_request
+
+jobs:
+  linux-gcc:
+    name: Build (Linux x86_64, GCC)
+    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    runs-on: ubuntu-18.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Set up Python (for Meson)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qqq build-essential ninja-build
+          python -m pip install --upgrade meson jinja2 inflection
+
+      - name: Build the library
+        run: |
+          meson builddir
+          meson compile -C builddir
+          ls -l builddir
+
+  linux-clang:
+    name: Build (Linux x86_64, Clang)
+    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    runs-on: ubuntu-18.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Set up Python (for Meson)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qqq build-essential ninja-build clang
+          python -m pip install --upgrade meson jinja2 inflection
+
+      - name: Build the library
+        run: |
+          CC=clang meson builddir
+          meson compile -C builddir
+          ls -l builddir
+
+  macos-clang:
+    name: Build (macOS x86_64, Clang)
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Set up Python (for Meson)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+
+      - name: Install dependencies
+        run: |
+          brew install ninja
+          python -m pip install --upgrade meson jinja2 inflection
+
+      - name: Build the library
+        run: |
+          meson builddir
+          meson compile -C builddir
+          ls -l builddir
+
+  windows-mingw:
+    name: Build (Windows x86_64, MinGW)
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Set up Python (for Meson)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+
+      - name: Install dependencies
+        run: |
+          choco install ninja
+          python -m pip install --upgrade meson jinja2 inflection
+
+      - name: Build the library
+        run: |
+          meson builddir
+          meson compile -C builddir
+          ls builddir
+
+  windows-msvc:
+    name: Build (Windows x86_64, MSVC)
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Set up Python (for Meson)
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+
+      - name: Install dependencies
+        run: |
+          choco install ninja
+          python -m pip install --upgrade meson jinja2 inflection
+
+      - name: Set up Visual Studio command prompt
+        uses: ilammy/msvc-dev-cmd@v1.5.0
+
+      - name: Build the library
+        run: |
+          meson builddir
+          meson compile -C builddir
+          ls builddir


### PR DESCRIPTION
I haven't figured out how to run the unit tests (`meson test -C builddir` says there are no tests to run). I could add this to the CI process once I know how to run unit tests :slightly_smiling_face:

Also, there's a linking error in the Windows MSVC job, but I don't know how to resolve that:

```
[4/25] Linking target ppelib.dll
FAILED: ppelib.dll ppelib.pdb 
"link"  /MACHINE:x64 /OUT:ppelib.dll  "/nologo" "/release" "/nologo" "/DEBUG" "/PDB:ppelib.pdb" "/DLL" "/IMPLIB:ppelib.lib" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
LINK : warning LNK4001: no object files specified; libraries used
LINK : error LNK2001: unresolved external symbol _DllMainCRTStartup
ppelib.dll : fatal error LNK1120: 1 unresolved externals
[5/25] Compiling C object src/ppelib-0.dll.p/ppelib-certificates.c.obj
ninja: build stopped: subcommand failed.
```